### PR TITLE
feat/if expressions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -33,7 +33,7 @@ pub struct InfixExpression {
 pub struct IfExpression {
   pub condition: Box<Expression>,
   pub consequence: Box<Statement>,
-  pub alternative: Box<Statement>,
+  pub alternative: Option<Box<Statement>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -60,11 +60,19 @@ impl fmt::Display for Expression {
         expression.left_operand, expression.operator, expression.right_operand
       ),
       Expression::Boolean(boolean) => write!(f, "{}", boolean),
-      Expression::If(expression) => write!(
-        f,
-        "({} {} {})",
-        expression.condition, expression.consequence, expression.alternative
-      ),
+      Expression::If(expression) => {
+        write!(
+          f,
+          "(if ({}) {}",
+          expression.condition, expression.consequence
+        )?;
+
+        if let Some(expression) = &expression.alternative {
+          write!(f, " else {})", expression)
+        } else {
+          write!(f, ")")
+        }
+      }
     }
   }
 }
@@ -106,13 +114,13 @@ impl fmt::Display for Statement {
       }
       Statement::Expression(statement) => statement.fmt(f),
       Statement::Block(statements) => {
-        write!(f, "{{")?;
+        write!(f, "{{ ")?;
 
         for statement in statements {
           statement.fmt(f)?;
         }
 
-        write!(f, "}}")
+        write!(f, " }}")
       }
     }
   }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,6 +29,12 @@ pub struct InfixExpression {
   pub operator: Token,
   pub right_operand: Box<Expression>,
 }
+#[derive(Debug, PartialEq)]
+pub struct IfExpression {
+  pub condition: Box<Expression>,
+  pub consequence: Box<Statement>,
+  pub alternative: Box<Statement>,
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Expression {
@@ -37,6 +43,7 @@ pub enum Expression {
   Prefix(PrefixExpression),
   Infix(InfixExpression),
   Boolean(bool),
+  If(IfExpression),
 }
 
 impl fmt::Display for Expression {
@@ -53,6 +60,11 @@ impl fmt::Display for Expression {
         expression.left_operand, expression.operator, expression.right_operand
       ),
       Expression::Boolean(boolean) => write!(f, "{}", boolean),
+      Expression::If(expression) => write!(
+        f,
+        "({} {} {})",
+        expression.condition, expression.consequence, expression.alternative
+      ),
     }
   }
 }
@@ -81,6 +93,7 @@ pub enum Statement {
   Let(LetStatement),
   Return(Expression),
   Expression(Expression),
+  Block(Vec<Statement>),
 }
 
 impl fmt::Display for Statement {
@@ -92,6 +105,15 @@ impl fmt::Display for Statement {
         statement.fmt(f)
       }
       Statement::Expression(statement) => statement.fmt(f),
+      Statement::Block(statements) => {
+        write!(f, "{{")?;
+
+        for statement in statements {
+          statement.fmt(f)?;
+        }
+
+        write!(f, "}}")
+      }
     }
   }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -317,6 +317,41 @@ mod tests {
       ("fn", vec![Token::Function, Token::Eof]),
       ("true", vec![Token::True, Token::Eof]),
       ("false", vec![Token::False, Token::Eof]),
+      ("if", vec![Token::If, Token::Eof]),
+      ("else", vec![Token::Else, Token::Eof]),
+      (
+        "if(x > 3) {}",
+        vec![
+          Token::If,
+          Token::LeftParen,
+          Token::Identifier(String::from("x")),
+          Token::GreaterThan,
+          Token::Number(String::from("3")),
+          Token::RightParen,
+          Token::LeftBrace,
+          Token::RightBrace,
+          Token::Eof,
+        ],
+      ),
+      (
+        "if(x > 3) { a } else { b }",
+        vec![
+          Token::If,
+          Token::LeftParen,
+          Token::Identifier(String::from("x")),
+          Token::GreaterThan,
+          Token::Number(String::from("3")),
+          Token::RightParen,
+          Token::LeftBrace,
+          Token::Identifier(String::from("a")),
+          Token::RightBrace,
+          Token::Else,
+          Token::LeftBrace,
+          Token::Identifier(String::from("b")),
+          Token::RightBrace,
+          Token::Eof,
+        ],
+      ),
     ];
 
     for (input, expected_tokens) in test_cases {

--- a/src/token.rs
+++ b/src/token.rs
@@ -30,6 +30,8 @@ pub enum Token {
   GreaterThanOrEqual,
   LessThanOrEqual,
   Pipe,
+  If,
+  Else,
 }
 
 impl fmt::Display for Token {
@@ -63,6 +65,8 @@ impl fmt::Display for Token {
       Token::GreaterThanOrEqual => write!(f, ">="),
       Token::LessThanOrEqual => write!(f, "<="),
       Token::Pipe => write!(f, "|>"),
+      Token::If => write!(f, "if"),
+      Token::Else => write!(f, "else"),
     }
   }
 }
@@ -74,6 +78,8 @@ pub fn lookup_identifier(lexeme: String) -> Token {
     "return" => Token::Return,
     "true" => Token::True,
     "false" => Token::False,
+    "if" => Token::If,
+    "else" => Token::Else,
     _ => Token::Identifier(lexeme),
   }
 }


### PR DESCRIPTION
- Adds support for `if` `[else]` expressions

```rust
let x = if(3 > 2) {
  5
} else {
  10
}

let y = if(5 == 10) {
  32
}
```

Todo:

Decide if `null` will be supported. Right now the second `if` expression behaviour is undefined if the consequence is not used