### PR TITLE
feat: support function literals

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -84,10 +84,10 @@ impl fmt::Display for Expression {
         write!(f, "(fn(")?;
 
         for (index, parameter) in function.paremeters.iter().enumerate() {
-          if index == 0 {
-            write!(f, "{}", parameter)?;
-          } else {
+          if index > 0 {
             write!(f, ", {}", parameter)?;
+          } else {
+            write!(f, "{}", parameter)?;
           }
         }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -37,6 +37,12 @@ pub struct IfExpression {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct FunctionExpression {
+  pub paremeters: Vec<Expression>,
+  pub body: Box<Statement>,
+}
+
+#[derive(Debug, PartialEq)]
 pub enum Expression {
   Identifier(String),
   Number(f64),
@@ -44,6 +50,7 @@ pub enum Expression {
   Infix(InfixExpression),
   Boolean(bool),
   If(IfExpression),
+  Function(FunctionExpression),
 }
 
 impl fmt::Display for Expression {
@@ -72,6 +79,23 @@ impl fmt::Display for Expression {
         } else {
           write!(f, ")")
         }
+      }
+      Expression::Function(function) => {
+        write!(f, "(fn(")?;
+
+        for (index, parameter) in function.paremeters.iter().enumerate() {
+          if index == 0 {
+            write!(f, "{}", parameter)?;
+          } else {
+            write!(f, ", {}", parameter)?;
+          }
+        }
+
+        write!(f, ") ")?;
+
+        function.body.fmt(f)?;
+
+        write!(f, ")")
       }
     }
   }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -327,7 +327,7 @@ impl Parser {
     let mut parameters: Vec<Expression> = Vec::new();
 
     while self.has_tokens_to_parse()
-      && !matches!(self.current_token(), Some(token) if token == &Token::RightParen)
+      && matches!(self.current_token(), Some(token) if token != &Token::RightParen)
     {
       match self.next_token() {
         Some(Token::Comma) => {}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -178,13 +178,6 @@ impl Parser {
     self.current_position < self.tokens.len() - 1
   }
 
-  fn current_token_is(&self, expected_token: Token) -> bool {
-    match self.current_token() {
-      Some(token) if token == &expected_token => true,
-      _ => false,
-    }
-  }
-
   fn current_token(&self) -> Option<&Token> {
     self.tokens.get(self.current_position)
   }
@@ -333,7 +326,9 @@ impl Parser {
 
     let mut parameters: Vec<Expression> = Vec::new();
 
-    while self.has_tokens_to_parse() && !self.current_token_is(Token::RightParen) {
+    while self.has_tokens_to_parse()
+      && !matches!(self.current_token(), Some(token) if token == &Token::RightParen)
+    {
       match self.next_token() {
         Some(Token::Comma) => {}
         Some(Token::Identifier(identifier)) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -178,6 +178,13 @@ impl Parser {
     self.current_position < self.tokens.len() - 1
   }
 
+  fn current_token_is(&self, expected_token: Token) -> bool {
+    match self.current_token() {
+      Some(token) if token == &expected_token => true,
+      _ => false,
+    }
+  }
+
   fn current_token(&self) -> Option<&Token> {
     self.tokens.get(self.current_position)
   }
@@ -326,7 +333,7 @@ impl Parser {
 
     let mut parameters: Vec<Expression> = Vec::new();
 
-    while self.has_tokens_to_parse() {
+    while self.has_tokens_to_parse() && !self.current_token_is(Token::RightParen) {
       match self.next_token() {
         Some(Token::Comma) => {}
         Some(Token::Identifier(identifier)) => {
@@ -339,6 +346,8 @@ impl Parser {
         }
       }
     }
+
+    self.consume(Token::RightParen);
 
     parameters
   }


### PR DESCRIPTION
- Adds function literal support

Examples:

```rust
let double = fn(x) { x * 2 }

let foo = fn() { 2 * 3 + 1 }

let bar = fn(x, y, z) { 
  let a = 10;
  let b = 10;
  return a + b * x * y * z;
}
```