### PR TITLE
feat/evaluate null literal

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -64,6 +64,7 @@ pub enum Expression {
   If(IfExpression),
   Function(FunctionExpression),
   Call(CallExpression),
+  Null,
 }
 
 impl fmt::Display for Expression {
@@ -128,6 +129,7 @@ impl fmt::Display for Expression {
 
         Ok(())
       }
+      Expression::Null => write!(f, "(null)"),
     }
   }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -4,7 +4,7 @@ use crate::ast::{Expression, Program, Statement};
 pub enum Object {
   Number(f64),
   Boolean(bool),
-  Unit,
+  Null,
 }
 
 pub struct Interpreter {
@@ -17,7 +17,7 @@ impl Interpreter {
   }
 
   pub fn evaluate(&self) -> Object {
-    let mut result: Object = Object::Unit;
+    let mut result: Object = Object::Null;
 
     for statement in &self.program.statements {
       result = self.eval(statement);
@@ -30,6 +30,7 @@ impl Interpreter {
     match statement {
       Statement::Expression(Expression::Number(number)) => Object::Number(*number),
       Statement::Expression(Expression::Boolean(t)) => Object::Boolean(*t),
+      Statement::Expression(Expression::Null) => Object::Null,
       _ => panic!("unexpected statement: {:?}", statement),
     }
   }
@@ -56,6 +57,7 @@ mod tests {
       ("941912921421", Object::Number(941912921421.0)),
       ("true", Object::Boolean(true)),
       ("false", Object::Boolean(false)),
+      ("null", Object::Null),
     ];
 
     for (input, expected) in test_cases {

--- a/src/token.rs
+++ b/src/token.rs
@@ -32,6 +32,7 @@ pub enum Token {
   Pipe,
   If,
   Else,
+  Null,
 }
 
 impl fmt::Display for Token {
@@ -67,6 +68,7 @@ impl fmt::Display for Token {
       Token::Pipe => write!(f, "|>"),
       Token::If => write!(f, "if"),
       Token::Else => write!(f, "else"),
+      Token::Null => write!(f, "null"),
     }
   }
 }
@@ -80,6 +82,7 @@ pub fn lookup_identifier(lexeme: String) -> Token {
     "false" => Token::False,
     "if" => Token::If,
     "else" => Token::Else,
+    "null" => Token::Null,
     _ => Token::Identifier(lexeme),
   }
 }


### PR DESCRIPTION
- [lexer] recognizes `null` as `Token::Null`
- [parser] Adds `Expression::Null` to ast
- [interpreter] Evaluates `null` literal