### PR TITLE
feat(interpreter): evaluate bindings

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -35,12 +35,6 @@ pub struct Environment {
 }
 
 impl Environment {
-  pub fn new() -> Self {
-    Environment {
-      scopes: vec![HashMap::new()],
-    }
-  }
-
   pub fn create_scope(&mut self) {
     self.scopes.push(HashMap::new());
   }
@@ -73,14 +67,16 @@ impl Environment {
 }
 
 pub struct Interpreter {
-  enviroment: Environment,
+  environment: Environment,
 }
 
 impl Interpreter {
   pub fn new() -> Self {
-    Interpreter {
-      enviroment: Environment::new(),
-    }
+    let mut environment = Environment { scopes: Vec::new() };
+
+    environment.scopes.push(HashMap::new());
+
+    Interpreter { environment }
   }
 
   pub fn evaluate(&mut self, program: &Program) -> Result<Object, InterpreterError> {
@@ -102,7 +98,7 @@ impl Interpreter {
         let identifier = statement.identifier.to_string();
         let value = self.eval_expression(&statement.value)?;
 
-        self.enviroment.set_binding(identifier, value.clone())?;
+        self.environment.set_binding(identifier, value.clone())?;
 
         Ok(value)
       }
@@ -190,7 +186,7 @@ impl Interpreter {
           _ => unreachable!(),
         }
       }
-      Expression::Identifier(identifier) => match self.enviroment.get_binding(&identifier) {
+      Expression::Identifier(identifier) => match self.environment.get_binding(&identifier) {
         Some(object) => Ok(object.clone()),
         None => Err(format!("identifier not found: {}", identifier)),
       },
@@ -203,7 +199,7 @@ impl Interpreter {
       Object::Boolean(_) => object,
       Object::Number(number) => Object::Boolean(number != 0.0),
       Object::Null => Object::Boolean(false),
-      Object::Identifier(identifier) => match self.enviroment.get_binding(&identifier) {
+      Object::Identifier(identifier) => match self.environment.get_binding(&identifier) {
         Some(object) => self.to_boolean(object.clone()),
         None => Object::Boolean(false),
       },

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -70,6 +70,12 @@ pub struct Interpreter {
   environment: Environment,
 }
 
+impl Default for Interpreter {
+  fn default() -> Self {
+    Interpreter::new()
+  }
+}
+
 impl Interpreter {
   pub fn new() -> Self {
     let mut environment = Environment { scopes: Vec::new() };
@@ -77,10 +83,6 @@ impl Interpreter {
     environment.scopes.push(HashMap::new());
 
     Interpreter { environment }
-  }
-
-  pub fn default() -> Self {
-    Interpreter::new()
   }
 
   pub fn evaluate(&mut self, program: &Program) -> Result<Object, InterpreterError> {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -67,7 +67,7 @@ impl Environment {
     }
   }
 
-  pub fn get_binding(&self, identifier: &String) -> Option<&Object> {
+  pub fn get_binding(&self, identifier: &str) -> Option<&Object> {
     self.scopes.last().and_then(|scope| scope.get(identifier))
   }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -79,6 +79,10 @@ impl Interpreter {
     Interpreter { environment }
   }
 
+  pub fn default() -> Self {
+    Interpreter::new()
+  }
+
   pub fn evaluate(&mut self, program: &Program) -> Result<Object, InterpreterError> {
     match self.eval_statements(&program.statements) {
       Ok(Object::Return(object)) => Ok(*object),


### PR DESCRIPTION
- Evaluates bindings

Examples:

```rust
 foobar // identifier not found: foobar
  
let a = 10
let a = 20 // identifier a is already declared in this scope

...
let a = 10
let b = 20
let a = 30 // identifier a is already declared in this scope
```