### PR TITLE
feat(interpreter): add builtin function len(String)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -798,6 +798,7 @@ mod tests {
         "len(fn(x){ x + 2})",
         "len() can't be used on (fn(x) (x + 2))",
       ),
+      ("len(x)", "identifier not found: x"),
     ];
 
     for (input, expected) in test_cases {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -83,6 +83,12 @@ pub struct Environment {
   scopes: Vec<HashMap<String, Object>>,
 }
 
+impl Default for Environment {
+  fn default() -> Self {
+    Environment::new()
+  }
+}
+
 impl Environment {
   pub fn new() -> Self {
     Environment {


### PR DESCRIPTION
- [Interpreter] adds builtin function `len(String)`

Examples:

```
len("hello world") // 11

"hello world" |> len // 11
```