### PR TITLE
feat/array index expression

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -55,6 +55,12 @@ pub struct CallExpression {
 }
 
 #[derive(Debug, PartialEq, Clone)]
+pub struct AcessExpression {
+  pub object: Expression,
+  pub key: Expression,
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
   Identifier(String),
   Number(f64),
@@ -67,6 +73,7 @@ pub enum Expression {
   Call(CallExpression),
   Array(Vec<Expression>),
   Null,
+  Access(Box<AcessExpression>),
 }
 
 impl fmt::Display for Expression {
@@ -159,6 +166,20 @@ impl fmt::Display for Expression {
         }
 
         write!(f, "])")
+      }
+      Expression::Access(expression) => {
+        write!(f, "(")?;
+
+        match expression.object {
+          Expression::Array(_) => {
+            expression.object.fmt(f)?;
+            write!(f, "[{}]", expression.key)?;
+          }
+
+          _ => unreachable!(),
+        }
+
+        write!(f, ")")
       }
     }
   }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -896,6 +896,13 @@ mod tests {
       ("[1, 2, 3][3]", Object::Null),
       ("[1, 2, 3][-1]", Object::Null),
       ("[1, 2, 3][2]", Object::Number(3.0)),
+      (
+        "
+        let index = 1
+        [1, 2, 3][index]
+      ",
+        Object::Number(2.0),
+      ),
     ];
 
     for (input, expected) in test_cases {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -895,7 +895,6 @@ mod tests {
       ("[1, 2, 3][0]", Object::Number(1.0)),
       ("[1, 2, 3][3]", Object::Null),
       ("[1, 2, 3][-1]", Object::Null),
-      ("[1, 2, 3][3]", Object::Null),
       ("[1, 2, 3][2]", Object::Number(3.0)),
     ];
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -375,7 +375,7 @@ impl Parser {
 
     let expression = Expression::Access(Box::new(AcessExpression {
       object: accessable_object,
-      key: key,
+      key,
     }));
 
     self.consume(Token::RightBracket);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,6 +13,7 @@ impl Precedence {
   pub const FACTOR: i32 = 7; // * /
   pub const UNARY: i32 = 8; // ! -
   pub const CALL: i32 = 9; // . () |>
+  pub const ACCESS: i32 = 10; // [...][number]
 }
 
 fn token_precedence(token: Option<&Token>) -> i32 {
@@ -25,6 +26,7 @@ fn token_precedence(token: Option<&Token>) -> i32 {
     Some(Token::Plus) | Some(Token::Minus) => Precedence::TERM,
     Some(Token::Star) | Some(Token::Slash) => Precedence::FACTOR,
     Some(Token::Pipe) | Some(Token::LeftParen) => Precedence::CALL,
+    Some(Token::LeftBracket) => Precedence::ACCESS,
     _ => Precedence::NONE,
   }
 }
@@ -159,6 +161,11 @@ impl Parser {
       Parser::parse_function_call_expression,
     );
 
+    parser.infix(
+      std::mem::discriminant(&Token::LeftBracket),
+      Parser::parse_access_expression,
+    );
+
     parser
   }
 
@@ -259,6 +266,12 @@ impl Parser {
             return Ok(left);
           }
 
+          if !matches!(&left, Expression::Array(_))
+            && matches!(self.current_token(), Some(Token::LeftBracket))
+          {
+            return Ok(left);
+          }
+
           token = self.next_token().cloned().unwrap();
 
           let infix_parselet = self
@@ -353,7 +366,24 @@ impl Parser {
     Expression::Array(elements)
   }
 
-  fn parse_function_literal(&mut self, _token: &Token) -> Expression {
+  fn parse_access_expression(
+    &mut self,
+    accessable_object: Expression,
+    _left_bracket: &Token,
+  ) -> Expression {
+    let key = self.parse_expression_statement(Precedence::NONE).unwrap();
+
+    let expression = Expression::Access(Box::new(AcessExpression {
+      object: accessable_object,
+      key: key,
+    }));
+
+    self.consume(Token::RightBracket);
+
+    expression
+  }
+
+  fn parse_function_literal(&mut self, _left_paren: &Token) -> Expression {
     let parameters = self.parse_function_parameters();
 
     let body = self.parse_block_statement();
@@ -804,6 +834,21 @@ mod tests {
       assert!(program.has_errors());
 
       assert_eq!(program.errors[0], expected);
+    }
+  }
+
+  #[test]
+  fn parse_array_index_expression() {
+    let test_cases = vec![("[1, 2, 3][0]", "(([1, 2, 3])[0])")];
+
+    for (input, expected) in test_cases {
+      let mut parser = Parser::new(Lexer::new(String::from(input)).lex().unwrap());
+
+      let program = parser.parse();
+
+      assert!(!program.has_errors());
+
+      assert_eq!(program.to_string(), expected);
     }
   }
 }


### PR DESCRIPTION
- Adds support for array access expressions

Examples:

```rust
[1, 2, 3][0] // 1
[1, 2, 3][3] // null
[1, 2, 3][-1] // null
[1, 2, 3][2] // 2

let index = 1
[1, 2, 3][index] // 2

[1, 2, 3][something thats not an integer] // error
```