### PR TITLE
Feat/array functions

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -272,7 +272,7 @@ impl Interpreter {
           .chars()
           .last()
           .map(|character| character.to_string())
-          .unwrap_or(String::from("")),
+          .unwrap_or_else(|| String::from("")),
       ))),
       object => Err(format!("last() can't be used on {}", object)),
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -267,13 +267,13 @@ impl Interpreter {
 
     match argument {
       Object::Array(objects) => Ok(objects.last().cloned().unwrap_or(Object::Null)),
-      Object::String(string) => Ok(Object::String(String::from(
+      Object::String(string) => Ok(Object::String(
         string
           .chars()
           .last()
           .map(|character| character.to_string())
           .unwrap_or_else(|| String::from("")),
-      ))),
+      )),
       object => Err(format!("last() can't be used on {}", object)),
     }
   }


### PR DESCRIPTION
- Adds `head(Array | String)`, `tail(Array | String)` and `last(Array | String)` builtin functions

Examples:

```rust
head([1, 2, 3]) // 1
head([]) // null

head("hello") // "h"
head("") // ""

tail([1, 2, 3]) // [2, 3]
tail([]) // null

head("hello") // "ello"
head("") // ""

last([1, 2, 3]) // 3
last([]) // null

last("hello") //  "o"
last("") // ""
```